### PR TITLE
SRCH-1889 (partial) - Disable RSpec/Description for task specs

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -77,6 +77,11 @@ Rails/SkipsModelValidations:
 # See also the list of RSpec statements that we exempt from the block
 # length cop, under Metrics/BlockLength above
 
+# For this group of specs, there is no class
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/lib/tasks/**'
+
 RSpec/ExampleLength:
   Enabled: false
 


### PR DESCRIPTION
For Rake tasks, there _isn't_ a class to use in the describe block, so
this cop is just annoying; there's no good way to do what it wants for
those specs. So turn it off for task specs.