### PR TITLE
SRCH-1969 raise MinSize threshold of Style/SymbolArray cop

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -116,3 +116,6 @@ Style/MixinUsage:
 
 Style/RescueStandardError:
   Enabled: false
+
+Style/SymbolArray:
+  MinSize: 4


### PR DESCRIPTION
This PR raises the `MinSize` threshold of the `Style/SymbolArray` cop, to allow small symbol arrays to use the more explicit syntax:
```ruby
# bad
[:foo, :bar, :baz, :biz]

# good
[:foo, :bar, :baz]

%i[foo bar baz biz]
```