### PR TITLE
SRCH-1972 downgrade Rubocop to 1.8.1

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,6 @@
+version: '2'
+
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-9-1
+    channel: rubocop-1-8-1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # searchgov_style
 
-Shared Rubocop configuration for Search.gov repositories
+Shared [Rubocop](https://rubocop.org/) configuration for Search.gov repositories
 
 ## Installation
 
@@ -49,6 +49,23 @@ Install the development gems:
 Run Rubocop on the gem repository itself:
 
     $ rubocop
+
+### Upgrading Rubocop
+
+To upgrade the version of Rubocop used by this gem, perform the
+following steps to ensure [compatibility with CodeClimate](https://docs.codeclimate.com/docs/rubocop#using-rubocops-newer-versions):
+
+1. Verify that the new version is supported by CodeClimate:  
+   [list of Rubocop channels for CodeClimate](https://github.com/codeclimate/codeclimate-rubocop/branches/all?utf8=%E2%9C%93&query=channel%2Frubocop)
+1. Verify that the new version is listed as a channel for the Rubocop engine for the CodeClimate CLI:  
+   [CodeClimate Engines](https://github.com/codeclimate/codeclimate/blob/master/config/engines.yml)
+1. Bump the version of Rubocop in the [gemspec](searchgov-style.gemspec)
+1. Bump the Rubocop channel in [.codeclimate.yml](.codeclimate.yml)
+
+You can verify your configuration and compatibility locally using the [CodeClimate CLI](https://github.com/codeclimate/codeclimate):
+
+    $ codeclimate validate-config
+    $ codeclimate analyze lib/ -e rubocop
 
 ## Contributing
 

--- a/searchgov-style.gemspec
+++ b/searchgov-style.gemspec
@@ -25,10 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'rake', '~> 13.0'
 
-  # Bumping Rubocop? Be sure the version is supported by CodeClimate,
-  # and set the channel in .codeclimate.yml
-  # https://docs.codeclimate.com/docs/rubocop#using-rubocops-newer-versions
-  spec.add_dependency 'rubocop', '1.9.1'
+  # Refer to the README for instructions on upgrading Rubocop
+  spec.add_dependency 'rubocop', '1.8.1'
   spec.add_dependency 'rubocop-performance', '~> 1.9'
   spec.add_dependency 'rubocop-rails', '~> 2.9'
   spec.add_dependency 'rubocop-rake', '~> 0.5'


### PR DESCRIPTION
@jmax-fearless , this PR temporarily downgrades Rubocop, as 1.9.1 turns out not to be supported yet by the CodeClimate CLI:
https://github.com/codeclimate/codeclimate/pull/1009