### PR TITLE
SRCH-2012 Added redirect_to and render methods to ignore list for parenthesis

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -111,6 +111,9 @@ Style/MethodCallWithArgsParentheses:
     - warn
     - error
     - fatal
+    # Ignore Rails controller DSL methods
+    - redirect_to
+    - render
   Exclude:
     - 'spec/**/*'
     - 'Gemfile'


### PR DESCRIPTION
Specifically, the Style/MethodCallWithArgsParentheses cop.