### PR TITLE
SRCH-2372 disable the Style/IfUnlessModifier cop

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -110,6 +110,9 @@ RSpec/NestedGroups:
 Style/Documentation:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Style/MethodCallWithArgsParentheses:
   Description: 'Use parentheses for method calls with arguments.'
   Enabled: true


### PR DESCRIPTION
Now that we've disabled the `Layout/LineLength` cop, the `Style/IfUnlessModifier cop` is trying to enforce and autocorrect a style that would often be worse than the original (an overly long `foo if bar` one-liner vs. a much more readable `if bar / foo /end`). We can disable this cop and leave the line wrapping to the developer's discretion.