### PR TITLE
SRCH-2385 ignore config/ & config.ru

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -9,17 +9,10 @@ AllCops:
   TargetRubyVersion: 2.5
   Exclude:
     - 'bin/**/*'
+    - 'config/**/*'
+    - 'config.ru'
     - 'db/**/*'
     - 'vendor/**/*'
-    # The following are (mostly) generated code; don't hold Rails'
-    # code generators to our coding standard.
-    - 'config/application.rb'
-    - 'config/boot.rb'
-    - 'config/environment.rb'
-    - 'config/environments/**/*'
-    - 'config/puma.rb'
-    - 'config/routes.rb'
-    - 'config/spring.rb'
 
 #### Bundler ####
 


### PR DESCRIPTION
After seeing another batch of offenses in other `config/` files for the Rails upgrades (as well as the auto-generated `config.ru`), I decided we can be more aggressive about ignoring those. We can self-police any custom initializers, etc., and save ourselves headaches each time we do a Rails upgrade.