### PR TITLE
SRCH-2498 exclude spec files from Lint/AmbiguousBlockAssociation

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -36,6 +36,12 @@ Layout/LineLength:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+#### Lint ####
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    # https://github.com/rubocop/rubocop/issues/4222#issuecomment-290655562
+    - 'spec/**/*'
+
 #### Metrics ####
 
 Metrics/BlockLength:


### PR DESCRIPTION
This PR excludes the `spec` directory from the `Lint/AmbiguousBlockAssociation` cop, as standard RSpec syntax will trigger this cop, including:
```ruby
expect { foo }.to change { bar }
```
https://github.com/rubocop/rubocop/issues/4222#issuecomment-290655562