### PR TITLE
SRCH-2497 add exclusions to Style/MethodCallWithArgsParentheses cop

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -124,9 +124,7 @@ Style/MethodCallWithArgsParentheses:
     - error
     - fatal
     # Ignore Rails DSL methods
-    # association methods other than has_many and HABTM are automatically excluded
-    - has_and_belongs_to_many
-    - has_many
+    - order
     - redirect_to
     - render
     - reset_callbacks

--- a/.default.yml
+++ b/.default.yml
@@ -124,6 +124,8 @@ Style/MethodCallWithArgsParentheses:
     - error
     - fatal
     # Ignore Rails DSL methods
+    - has_many
+    - has_one
     - order
     - redirect_to
     - render

--- a/.default.yml
+++ b/.default.yml
@@ -123,9 +123,15 @@ Style/MethodCallWithArgsParentheses:
     - warn
     - error
     - fatal
-    # Ignore Rails controller DSL methods
+    # Ignore Rails DSL methods
+    # association methods other than has_many and HABTM are automatically excluded
+    - has_and_belongs_to_many
+    - has_many
     - redirect_to
     - render
+    - reset_callbacks
+    - set_callback
+    - skip_callback
   Exclude:
     - 'spec/**/*'
     - 'Gemfile'


### PR DESCRIPTION
This PR excludes some additional Rails DSL methods from the `Style/MethodCallWithArgsParentheses` cop, as the style guide specifies to "Always omit parentheses for methods that are part of an internal DSL (e.g., Rake, Rails, RSpec)":
https://rubystyle.guide/#methods-that-are-part-of-an-internal-dsl