### PR TITLE
SRCH-2589 Turn off Rubocop RSpec/DescribeClass for system specs.

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -78,6 +78,9 @@ Rails/SkipsModelValidations:
 # length cop, under Metrics/BlockLength above
 
 # For this group of specs, there is no class
+# We can remove these exclusions once we're using rubocop-rspec >= 2.5 & rubocop >= 1.19,
+# which depend on unreleased changes to the Code Climate CLI:
+# https://github.com/codeclimate/codeclimate/commit/ab6ef5ce65afad5356ed3d558ac73dbc4fd4d49f
 RSpec/DescribeClass:
   Exclude:
     - 'spec/lib/tasks/**/*'

--- a/.default.yml
+++ b/.default.yml
@@ -80,8 +80,8 @@ Rails/SkipsModelValidations:
 # For this group of specs, there is no class
 RSpec/DescribeClass:
   Exclude:
-    - 'spec/lib/tasks/**'
-    - 'spec/system/**'
+    - 'spec/lib/tasks/**/*'
+    - 'spec/system/**/*'
 
 RSpec/DescribedClass:
   SkipBlocks: true


### PR DESCRIPTION
This will be fixed when we can move to v. 2.5 of rubocop-rspec.