### PR TITLE
SRCH-2786 count multi-line arrays, hashes, & heredocs as one line

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,4 +3,4 @@ version: '2'
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-8-1
+    channel: rubocop-1-23-0

--- a/.default.yml
+++ b/.default.yml
@@ -57,6 +57,12 @@ Metrics/BlockLength:
     - include_context
     - shared_examples_for
 
+Metrics/MethodLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+
 #### Performance ####
 
 Performance/TimesMap:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,9 @@ Please ensure you have addressed all concerns below before marking a PR "ready f
 
 - [ ] Automated checks pass, if applicable. If checks do not pass, explain reason for failures:
 
+- [ ] You have [upgraded Rubocop](https://github.com/GSA/searchgov_style#upgrading-rubocop) to the highest version supported by
+  CodeClimate
+
 - [ ] You have merged the latest changes from `main` into your branch.
  
 - [ ] Your target branch is `main`, or you have specified the reason for an alternate branch here:

--- a/searchgov-style.gemspec
+++ b/searchgov-style.gemspec
@@ -13,8 +13,11 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
-  spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/GSA/searchgov_style'
+  spec.metadata = {
+    'homepage_uri' => spec.homepage,
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => 'https://github.com/GSA/searchgov_style'
+  }
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -26,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
 
   # Refer to the README for instructions on upgrading Rubocop
-  spec.add_dependency 'rubocop', '1.8.1'
+  spec.add_dependency 'rubocop', '1.23.0'
   spec.add_dependency 'rubocop-performance', '~> 1.9'
   spec.add_dependency 'rubocop-rails', '~> 2.9'
   spec.add_dependency 'rubocop-rake', '~> 0.5'


### PR DESCRIPTION
## Summary
This PR updates the `Metrics/MethodLength` cop to count multi-line arrays, hashes, & heredocs as a single line. This prevents methods such as the following from being flagged as having `too many lines`:
```ruby
def my_method
  [
    1
    2
    3
  ]
end
```

It also:
- bumps the `rubocop` version to 1.23.0
- updates the PR template to require the `rubocop` bump
- updates the gemspec to require MFA (this change was necessary after bumping rubocop)
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:
 
#### Functionality Checks
 
- [x] Code is functional, as tested locally.

- [x] Automated checks pass, if applicable. If checks do not pass, explain reason for failures:

- [x] You have [upgraded Rubocop](https://github.com/GSA/searchgov_style#upgrading-rubocop) to the highest version supported by CodeClimate

- [x] You have merged the latest changes from `main` into your branch.
 
- [x] Your target branch is `main`, or you have specified the reason for an alternate branch here:
 
- [x] PR title is of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X").
 
- [x] You have squashed your commits into a single commit.
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers.