### PR TITLE
SRCH-2643 Update searchgov-style to Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
       - checkout
       # Install gems with Bundler
       - ruby/install-deps:
-          with-cache: false
+          # Need to clear the gem cache? Set or bump the CACHE_VERSION in your
+          # CircleCi project: Project Settings > Environment Variables
+          key: searchgov_style-{{ .Environment.CACHE_VERSION }}-{{checksum "Gemfile.lock" }}
       - run:
           name: Rubocop
           # CodeClimate will also run Rubocop, but only on PRs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,17 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.1.2
+  ruby: circleci/ruby@1.4.0
 
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.7
+      - image: cimg/ruby:2.7.5
     executor: ruby/default
     steps:
       - checkout
-      - run:
-          name: Install Bundler
-          command: gem install bundler:2.2
-      - ruby/bundle-install
+      # Install gems with Bundler
+      - ruby/install-deps:
+          with-cache: false
       - run:
           name: Rubocop
           # CodeClimate will also run Rubocop, but only on PRs.

--- a/.default.yml
+++ b/.default.yml
@@ -82,6 +82,10 @@ Rails/SkipsModelValidations:
 # See also the list of RSpec statements that we exempt from the block
 # length cop, under Metrics/BlockLength above
 
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/lib/tasks/**/*'
+
 RSpec/DescribedClass:
   SkipBlocks: true
 

--- a/.default.yml
+++ b/.default.yml
@@ -6,7 +6,6 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
   Exclude:
     - 'bin/**/*'
     - 'config/**/*'
@@ -82,15 +81,6 @@ Rails/SkipsModelValidations:
 
 # See also the list of RSpec statements that we exempt from the block
 # length cop, under Metrics/BlockLength above
-
-# For this group of specs, there is no class
-# We can remove these exclusions once we're using rubocop-rspec >= 2.5 & rubocop >= 1.19,
-# which depend on unreleased changes to the Code Climate CLI:
-# https://github.com/codeclimate/codeclimate/commit/ab6ef5ce65afad5356ed3d558ac73dbc4fd4d49f
-RSpec/DescribeClass:
-  Exclude:
-    - 'spec/lib/tasks/**/*'
-    - 'spec/system/**/*'
 
 RSpec/DescribedClass:
   SkipBlocks: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 /doc/
 /pkg/
 /tmp/
-/Gemfile.lock
 *.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,70 @@
+PATH
+  remote: .
+  specs:
+    searchgov_style (0.1.15)
+      rubocop (= 1.23.0)
+      rubocop-performance (~> 1.9)
+      rubocop-rails (~> 2.9)
+      rubocop-rake (~> 0.5)
+      rubocop-rspec (~> 2.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.1.4.7)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    ast (2.4.2)
+    concurrent-ruby (1.1.9)
+    i18n (1.10.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.15.0)
+    parallel (1.21.0)
+    parser (3.1.1.0)
+      ast (~> 2.4.1)
+    rack (2.2.3)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.2.1)
+    rexml (3.2.5)
+    rubocop (1.23.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.12.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.16.0)
+      parser (>= 3.1.1.0)
+    rubocop-performance (1.13.3)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.13.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.9.0)
+      rubocop (~> 1.19)
+    ruby-progressbar (1.11.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.1.0)
+    zeitwerk (2.5.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.2)
+  rake (~> 13.0)
+  searchgov_style!
+
+BUNDLED WITH
+   2.3.8

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ following steps to ensure [compatibility with CodeClimate](https://docs.codeclim
 1. Bump the version of Rubocop in the [gemspec](searchgov-style.gemspec)
 1. Bump the Rubocop channel in [.codeclimate.yml](.codeclimate.yml)
 
-You can verify your configuration and compatibility locally using the [CodeClimate CLI](https://github.com/codeclimate/codeclimate):
+Verify your configuration and compatibility locally using the [CodeClimate CLI](https://github.com/codeclimate/codeclimate):
 
+    $ bundle update
     $ codeclimate validate-config
     $ codeclimate analyze lib/ -e rubocop
 

--- a/searchgov-style.gemspec
+++ b/searchgov-style.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-performance', '~> 1.9'
   spec.add_dependency 'rubocop-rails', '~> 2.9'
   spec.add_dependency 'rubocop-rake', '~> 0.5'
-  spec.add_dependency 'rubocop-rspec', '~> 2.1'
+  spec.add_dependency 'rubocop-rspec', '~> 2.5'
 end


### PR DESCRIPTION
## Summary
- Updates to Ruby 2.7
- Updates to latest circleci orb and new style docker image
- Because we are moving to using `ruby/install-deps` and relying on the orb for bundler ("By default, it gets the bundler version from Gemfile.lock."), we've got to make the `Gemfile.lock` available and move it out of `.gitignore`  
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:
 
#### Functionality Checks
 
- [x] Code is functional, as tested locally.

- [x] Automated checks pass, if applicable. If checks do not pass, explain reason for failures:
Link to passing checks on fork in comments below

- [x] You have [upgraded Rubocop](https://github.com/GSA/searchgov_style#upgrading-rubocop) to the highest version supported by CodeClimate
N/A already at highest version

- [x] You have merged the latest changes from `main` into your branch.
 
- [x] Your target branch is `main`, or you have specified the reason for an alternate branch here:
 
- [x] PR title is of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X").
 
- [x] You have squashed your commits into a single commit.
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers.
