### PR TITLE
SRCH-3753 CountAsOne configurations for Metrics/ClassLength

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -60,7 +60,6 @@ Metrics/ClassLength:
     - array
     - hash
     - heredoc
-    - method_call
 
 Metrics/MethodLength:
   CountAsOne:

--- a/.default.yml
+++ b/.default.yml
@@ -55,6 +55,13 @@ Metrics/BlockLength:
     - '*.gemspec'
     - 'spec/**/*'
 
+Metrics/ClassLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+    - method_call
+
 Metrics/MethodLength:
   CountAsOne:
     - array

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -25,10 +25,10 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
-    rack (3.0.3)
+    rack (3.0.4.1)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.6.1)
+    regexp_parser (2.6.2)
     rexml (3.2.5)
     rubocop (1.39.0)
       json (~> 2.3)
@@ -51,12 +51,12 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.16.0)
+    rubocop-rspec (2.17.1)
       rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.4.0)
+    unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## Summary
- Configures searchgov_style's ClassLength cop to count multi-line arrays, hashes, heredocs, and method calls as one line.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks

- [x] You have [upgraded Rubocop](https://github.com/GSA/searchgov_style#upgrading-rubocop) to the highest version supported by Code Climate
Already at 1.39

- [x] You have merged the latest changes from (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket

- [x] PR title is of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X").

- [x] Automated checks pass, if applicable. If checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".