### PR TITLE
SRCH-3742 update obsolete param name

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -46,7 +46,7 @@ Lint/AmbiguousBlockAssociation:
 Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Max: 25
-  IgnoredMethods:
+  AllowedMethods:
     # By default, exclude the `#refine` method, as it tends to have larger
     # associated blocks.
     - refine
@@ -131,7 +131,7 @@ Style/IfUnlessModifier:
 Style/MethodCallWithArgsParentheses:
   Description: 'Use parentheses for method calls with arguments.'
   Enabled: true
-  IgnoredMethods:
+  AllowedMethods:
     # Ignore Ruby keyword methods:
     # https://rubystyle.guide/#methods-that-have-keyword-status-in-ruby
     - require


### PR DESCRIPTION
## Summary
- Updates obsolete `IgnoredMethods` to `AllowedMethods` to resolve:

```
Warning: obsolete parameter `IgnoredMethods` (for `Metrics/BlockLength`) found in .rubocop-https---raw-githubusercontent-com-GSA-searchgov-style-main--default-yml
`IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`.
```

- Follow on tasks in each repo will do the same update in their respective `.rubocop.yml` and bump searchgov_style

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks

- [x] You have [upgraded Rubocop](https://github.com/GSA/searchgov_style#upgrading-rubocop) to the highest version supported by Code Climate
  1.48.1 not quite there yet.

- [x] You have merged the latest changes from (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket

- [x] PR title is of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X").

- [x] Automated checks pass, if applicable. If checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".