### PR TITLE
SRCH-4258 disable Style/FrozenStringLiteralComment cop for specs

### DIFF
--- a/.default.yml
+++ b/.default.yml
@@ -125,6 +125,10 @@ RSpec/NestedGroups:
 Style/Documentation:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'spec/**/*'
+
 Style/IfUnlessModifier:
   Enabled: false
 


### PR DESCRIPTION
## Summary
This PR disables the `Style/FrozenStringLiteralComment` cop for specs.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks

- ⚠️  You have [upgraded Rubocop](https://github.com/GSA/searchgov_style#upgrading-rubocop) to the highest version supported by Code Climate - I skipped this, as the previous commit from earlier today did that.

- [x] You have merged the latest changes from (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket

- [x] PR title is of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X").

- [x] Automated checks pass, if applicable. If checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".